### PR TITLE
Fix search path for nvim sockets

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -12,7 +12,8 @@ rustPlatform.buildRustPackage {
 
   src = ./.;
 
-  cargoHash = "sha256-gEgSb2DkiGBVmSMt3whVLbCEOrPQKhtWvIhnbUDBYOk=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-tNCSGL0xelWtSZnSHV0l27vh8iYFeFoiFCAD/BPCNnI=";
 
   meta = {
     description = "Control neovim instances using the command line";

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,22 @@
+{ lib
+, rustPlatform
+}:
+
+let
+  cargoToml = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package;
+in
+
+rustPlatform.buildRustPackage {
+  pname = cargoToml.name;
+  version = cargoToml.version;
+
+  src = ./.;
+
+  cargoHash = "sha256-gEgSb2DkiGBVmSMt3whVLbCEOrPQKhtWvIhnbUDBYOk=";
+
+  meta = {
+    description = "Control neovim instances using the command line";
+    homepage = "https://github.com/Samasaur1/nvim-ctrl";
+    mainProgram = "nvim-ctrl";
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1702539185,
+        "narHash": "sha256-KnIRG5NMdLIpEkZTnN5zovNYc0hhXjAgv6pfd5Z4c7U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "aa9d4729cbc99dabacb50e3994dcefb3ea0f7447",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1702539185,
-        "narHash": "sha256-KnIRG5NMdLIpEkZTnN5zovNYc0hhXjAgv6pfd5Z4c7U=",
+        "lastModified": 1740532964,
+        "narHash": "sha256-kRPDOnpv6OhrJRHJtVaQ/i04dHCz74ndmjA2Y5Hu6t0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aa9d4729cbc99dabacb50e3994dcefb3ea0f7447",
+        "rev": "04fa2a8dbae35879e96dab9115a20d78e8527994",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Control neovim instances using the command line";
+
+  outputs = { nixpkgs, ... }:
+    let
+      forAllSystems = gen:
+        nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed
+        (system: gen nixpkgs.legacyPackages.${system});
+    in {
+      packages = forAllSystems (pkgs: { default = pkgs.callPackage ./. { }; });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,8 @@
 {
   description = "Control neovim instances using the command line";
 
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs";
+
   outputs = { nixpkgs, ... }:
     let
       forAllSystems = gen:

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/wxfszk1cxj86qc54a4c399dic4b1xgg1-nvim-ctrl-0.1.0

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@ use structopt::StructOpt;
 struct Control {
     /// run an arbitrary command
     cmd: String,
+    #[structopt(default_value = "nvim", long)]
+    vim_type: String
 }
 
 fn main() -> Result<()> {
@@ -20,7 +22,7 @@ fn main() -> Result<()> {
                 let is_dir =
                     matches!(f.file_type().map(|t| t.is_dir()), Ok(true));
                 let name_heuristic =
-                    f.file_name().to_string_lossy().starts_with("nvim");
+                    f.file_name().to_string_lossy().starts_with(&args.vim_type);
                 is_dir && name_heuristic
             })
             .filter_map(|dir| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,12 +8,19 @@ struct Control {
     /// run an arbitrary command
     cmd: String,
     #[structopt(default_value = "nvim", long)]
-    vim_type: String
+    vim_type: String,
+    #[structopt(long)]
+    file: Option<String>
 }
 
 fn main() -> Result<()> {
     let args = Control::from_args();
     let tmp = std::env::var("TMPDIR").unwrap_or("/tmp".to_owned());
+
+    let full_file = match args.file {
+        None => None,
+        Some(ref f) => std::fs::canonicalize(f).ok()
+    };
 
     match std::fs::read_dir(tmp) {
         Ok(dir) => dir
@@ -49,9 +56,23 @@ fn main() -> Result<()> {
                 Neovim::new(session)
             })
             .for_each(|mut nvim| {
-                let _ = nvim
-                    .command(&args.cmd)
-                    .map_err(|e| eprintln!("Error: {}", e));
+                if let Some(full_file) = full_file.clone() {
+                    let full_buf_name = nvim.get_current_buf()
+                        .iter().flat_map(|buf| buf.get_name(&mut nvim))
+                        .flat_map(|bufname| std::fs::canonicalize(bufname))
+                        .collect::<Vec<_>>();
+                    if Some(&full_file) == full_buf_name.get(0) {
+                        let _ = nvim
+                            .command(&args.cmd)
+                            .map_err(|e| eprintln!("Error: {}", e));
+                    } else {
+                        println!("Skipping non-matching file {:?}", full_buf_name.get(0))
+                    }
+                } else {
+                    let _ = nvim
+                        .command(&args.cmd)
+                        .map_err(|e| eprintln!("Error: {}", e));
+                }
             }),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(e) => Err(e)?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,15 @@ fn main() -> Result<()> {
                 )
             })
             .flatten()
+            .filter_map(|dir| {
+                Some(
+                    std::fs::read_dir(dir)
+                        .ok()?
+                        .filter_map(Result::ok)
+                        .map(|d| d.path()),
+                )
+            })
+            .flatten()
             .filter_map(|d| Session::new_unix_socket(d).ok())
             .map(|mut session| {
                 session.start_event_loop();

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,68 +15,69 @@ struct Control {
 
 fn main() -> Result<()> {
     let args = Control::from_args();
-    let tmp = std::env::var("TMPDIR").unwrap_or("/tmp".to_owned());
 
     let full_file = match args.file {
         None => None,
         Some(ref f) => std::fs::canonicalize(f).ok()
     };
 
-    match std::fs::read_dir(tmp) {
-        Ok(dir) => dir
-            .filter_map(|f| f.ok())
-            .filter(|f| {
-                let is_dir =
-                    matches!(f.file_type().map(|t| t.is_dir()), Ok(true));
-                let name_heuristic =
-                    f.file_name().to_string_lossy().starts_with(&args.vim_type);
-                is_dir && name_heuristic
-            })
-            .filter_map(|dir| {
-                Some(
-                    std::fs::read_dir(dir.path())
-                        .ok()?
-                        .filter_map(Result::ok)
-                        .map(|d| d.path()),
-                )
-            })
-            .flatten()
-            .filter_map(|dir| {
-                Some(
-                    std::fs::read_dir(dir)
-                        .ok()?
-                        .filter_map(Result::ok)
-                        .map(|d| d.path()),
-                )
-            })
-            .flatten()
-            .filter_map(|d| Session::new_unix_socket(d).ok())
-            .map(|mut session| {
-                session.start_event_loop();
-                Neovim::new(session)
-            })
-            .for_each(|mut nvim| {
-                if let Some(full_file) = full_file.clone() {
-                    let full_buf_name = nvim.get_current_buf()
-                        .iter().flat_map(|buf| buf.get_name(&mut nvim))
-                        .flat_map(|bufname| std::fs::canonicalize(bufname))
-                        .collect::<Vec<_>>();
-                    if Some(&full_file) == full_buf_name.get(0) {
+    vec![std::env::var("TMPDIR").ok(), Some(String::from("/tmp"))]
+        .into_iter()
+        .flatten()
+        .filter_map(|tmpdir| std::fs::read_dir(tmpdir).ok())
+        .for_each(|dir| {
+            dir
+                .filter_map(|f| f.ok())
+                .filter(|f| {
+                    let is_dir =
+                        matches!(f.file_type().map(|t| t.is_dir()), Ok(true));
+                    let name_heuristic =
+                        f.file_name().to_string_lossy().starts_with(&args.vim_type);
+                    is_dir && name_heuristic
+                })
+                .filter_map(|dir| {
+                    Some(
+                        std::fs::read_dir(dir.path())
+                            .ok()?
+                            .filter_map(Result::ok)
+                            .map(|d| d.path()),
+                    )
+                })
+                .flatten()
+                .filter_map(|dir| {
+                    Some(
+                        std::fs::read_dir(dir)
+                            .ok()?
+                            .filter_map(Result::ok)
+                            .map(|d| d.path()),
+                    )
+                })
+                .flatten()
+                .filter_map(|d| Session::new_unix_socket(d).ok())
+                .map(|mut session| {
+                    session.start_event_loop();
+                    Neovim::new(session)
+                })
+                .for_each(|mut nvim| {
+                    if let Some(full_file) = full_file.clone() {
+                        let full_buf_name = nvim.get_current_buf()
+                            .iter().flat_map(|buf| buf.get_name(&mut nvim))
+                            .flat_map(|bufname| std::fs::canonicalize(bufname))
+                            .collect::<Vec<_>>();
+                        if Some(&full_file) == full_buf_name.get(0) {
+                            let _ = nvim
+                                .command(&args.cmd)
+                                .map_err(|e| eprintln!("Error: {}", e));
+                        } else {
+                            println!("Skipping non-matching file {:?}", full_buf_name.get(0))
+                        }
+                    } else {
                         let _ = nvim
                             .command(&args.cmd)
                             .map_err(|e| eprintln!("Error: {}", e));
-                    } else {
-                        println!("Skipping non-matching file {:?}", full_buf_name.get(0))
                     }
-                } else {
-                    let _ = nvim
-                        .command(&args.cmd)
-                        .map_err(|e| eprintln!("Error: {}", e));
-                }
-            }),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(e) => Err(e)?,
-    }
+                })
+        });
 
     Ok(())
 }


### PR DESCRIPTION
Apparently at some point, nvim added another intermediary directory, which was the reason that this tool wasn't working. It should now be working.