### PR TITLE
Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,95 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1707092692,
+        "narHash": "sha256-ZbHsm+mGk/izkWtT4xwwqz38fdlwu7nUUKXTOmm4SyE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "faf912b086576fd1a15fca610166c98d47bc667e",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1706487304,
+        "narHash": "sha256-LE8lVX28MV2jWJsidW13D2qrHU/RUUONendL2Q/WlJg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "90f456026d284c22b3e3497be980b2e47d0b28ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1707185459,
+        "narHash": "sha256-+GdqwnFZQ9G6pOrTGA+XzD4hg+DZZwkx2/x46fuNkL8=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "be473291b92e4e84e84a1e04e57481c848060c6c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,54 @@
+{
+  description = "Flake to package nvim-ctrl";
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+  outputs = { self, nixpkgs, rust-overlay }: 
+    let
+    # Systems supported
+    allSystems = [
+      "x86_64-linux" # 64-bit Intel/AMD Linux
+      "aarch64-linux" # 64-bit ARM Linux
+      "x86_64-darwin" # 64-bit Intel macOS
+      "aarch64-darwin" # 64-bit ARM macOS
+    ];
+
+    # Helper to provide system-specific attributes
+    forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [
+          # Provides Nixpkgs with a rust-bin attribute for building Rust toolchains
+          rust-overlay.overlays.default
+          # Uses the rust-bin attribute to select a Rust toolchain
+          self.overlays.default
+        ];
+      };
+    });
+    in
+    {
+      overlays.default = final: prev: {
+        # The Rust toolchain used for the package build
+        rustToolchain = final.rust-bin.stable.latest.default;
+      };
+
+      packages = forAllSystems ({ pkgs }: {
+        default =
+          let
+            rustPlatform = pkgs.makeRustPlatform {
+              cargo = pkgs.rustToolchain;
+              rustc = pkgs.rustToolchain;
+            };
+            in
+            rustPlatform.buildRustPackage {
+              name = "nvim-ctrl";
+              src = ./.;
+              cargoLock = {
+                lockFile = ./Cargo.lock;
+              };
+            };
+      });
+    }; 
+}


### PR DESCRIPTION
Created a nix flake for this project so people can easily run it from nixos or nix on a different system with flakes enabled. 

Here's a picture of how a Nix or Nixos user would run this (from my branch)

![image](https://github.com/chmln/nvim-ctrl/assets/53587182/81c48712-0841-4c27-9fb1-443057ce9804)

If this were merged, it would be run like this:

```bash
nix run github:chmin/nvim-ctrl
```

I'm not that good at nix, and most of this was copied from zero-to-nix, so I can't promise maintenance until I become better at the language. I'd understand if this can't be merged, but I figured I'd create the PR JIC.